### PR TITLE
Add Simple Maillage SEO plugin example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,5 @@
-# sms
+# Simple Maillage SEO
+
+Ce dépôt contient un exemple de plugin WordPress destiné à simplifier le maillage interne pour les débutants. Le plugin ajoute une interface dans l'administration afin d'associer des mots clés à des URL et de les appliquer automatiquement dans tout le contenu du site.
+
+Reportez-vous au dossier `simple-maillage-seo` pour les fichiers du plugin et les instructions d'installation.

--- a/simple-maillage-seo/README.md
+++ b/simple-maillage-seo/README.md
@@ -1,0 +1,15 @@
+# Simple Maillage SEO
+
+Ce plugin WordPress permet de créer facilement des liens internes sur tout le site. Il ajoute un tableau de bord dans l'administration où vous pouvez définir des couples **mot clé / URL**. Chaque fois qu'un mot clé est validé, le plugin ajoute automatiquement un lien sur la première occurrence disponible dans le contenu de vos pages et articles.
+
+## Installation
+
+1. Copier le dossier `simple-maillage-seo` dans le répertoire `wp-content/plugins/` de votre site WordPress.
+2. Activer l'extension "Simple Maillage SEO" depuis l'administration WordPress.
+
+## Utilisation
+
+- Dans le menu "Maillage SEO", saisissez un mot clé et l'URL cible puis cliquez sur **Valider**.
+- Le mot clé apparait dans la liste et peut être supprimé à tout moment.
+- L'URL est automatiquement liée à la première occurrence du mot clé présente dans vos articles et pages existants.
+

--- a/simple-maillage-seo/simple-maillage-seo.php
+++ b/simple-maillage-seo/simple-maillage-seo.php
@@ -1,0 +1,145 @@
+<?php
+/*
+Plugin Name: Simple Maillage SEO
+Plugin URI: https://x.com/Sulfamique
+Description: Plugin SEO pour un maillage interne automatique et simple.
+Version: 1.0
+Author: Sulfamique
+Author URI: https://github.com/Sulfamique/
+License: aucune idee
+*/
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit; // Quitter si accès direct
+}
+
+class SimpleMaillageSEO {
+
+    private static $option_key = 'sms_keyword_links';
+
+    public static function init() {
+        add_action( 'admin_menu', array( __CLASS__, 'add_admin_menu' ) );
+        add_action( 'admin_init', array( __CLASS__, 'handle_form_submission' ) );
+        add_filter( 'the_content', array( __CLASS__, 'apply_links' ) );
+    }
+
+    public static function get_links() {
+        $links = get_option( self::$option_key, array() );
+        return is_array( $links ) ? $links : array();
+    }
+
+    public static function save_links( $links ) {
+        update_option( self::$option_key, $links );
+    }
+
+    public static function add_admin_menu() {
+        add_menu_page(
+            'Simple Maillage SEO',
+            'Maillage SEO',
+            'manage_options',
+            'simple-maillage-seo',
+            array( __CLASS__, 'admin_page' )
+        );
+    }
+
+    public static function handle_form_submission() {
+        if ( ! current_user_can( 'manage_options' ) ) {
+            return;
+        }
+
+        if ( isset( $_POST['sms_add'] ) && check_admin_referer( 'sms_save_links' ) ) {
+            $keyword = sanitize_text_field( $_POST['sms_keyword'] );
+            $url     = esc_url_raw( $_POST['sms_url'] );
+            if ( $keyword && $url ) {
+                $links = self::get_links();
+                $links[ $keyword ] = $url;
+                self::save_links( $links );
+            }
+        }
+
+        if ( isset( $_POST['sms_delete'] ) && isset( $_POST['sms_keyword_delete'] ) && check_admin_referer( 'sms_save_links' ) ) {
+            $del = sanitize_text_field( $_POST['sms_keyword_delete'] );
+            $links = self::get_links();
+            if ( isset( $links[ $del ] ) ) {
+                unset( $links[ $del ] );
+                self::save_links( $links );
+            }
+        }
+    }
+
+    public static function admin_page() {
+        ?>
+        <div class="wrap">
+            <h1>Simple Maillage SEO</h1>
+            <form method="post">
+                <?php wp_nonce_field( 'sms_save_links' ); ?>
+                <table class="widefat">
+                    <thead>
+                        <tr>
+                            <th>Mot clef</th>
+                            <th>URL</th>
+                            <th>Actions</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <?php foreach ( self::get_links() as $kw => $url ) : ?>
+                            <tr>
+                                <td><?php echo esc_html( $kw ); ?></td>
+                                <td><?php echo esc_url( $url ); ?></td>
+                                <td>
+                                    <button type="submit" name="sms_delete" class="button-link-delete" value="1">Supprimer</button>
+                                    <input type="hidden" name="sms_keyword_delete" value="<?php echo esc_attr( $kw ); ?>" />
+                                </td>
+                            </tr>
+                        <?php endforeach; ?>
+                        <tr>
+                            <td><input type="text" name="sms_keyword" /></td>
+                            <td><input type="url" name="sms_url" /></td>
+                            <td><button type="submit" name="sms_add" class="button button-primary" value="1">Valider</button></td>
+                        </tr>
+                    </tbody>
+                </table>
+            </form>
+        </div>
+        <?php
+    }
+
+    public static function apply_links( $content ) {
+        $links = self::get_links();
+        if ( empty( $links ) ) {
+            return $content;
+        }
+
+        libxml_use_internal_errors( true );
+        $dom = new DOMDocument();
+        $encoding = get_bloginfo( 'charset' );
+        $dom->loadHTML( '<?xml encoding="' . $encoding . '"?>' . $content );
+        $xpath = new DOMXPath( $dom );
+
+        foreach ( $links as $keyword => $url ) {
+            $nodes = $xpath->query( '//text()[not(ancestor::a) and not(ancestor::h1) and not(ancestor::h2) and not(ancestor::h3) and not(ancestor::h4) and not(ancestor::h5) and not(ancestor::h6)]' );
+            foreach ( $nodes as $node ) {
+                if ( stripos( $node->nodeValue, $keyword ) !== false ) {
+                    $regex = '/(\b' . preg_quote( $keyword, '/' ) . '\b)/i';
+                    $new = preg_replace( $regex, '<a href="' . esc_url( $url ) . '">$1</a>', $node->nodeValue, 1 );
+                    if ( $new !== $node->nodeValue ) {
+                        $frag = $dom->createDocumentFragment();
+                        $frag->appendXML( $new );
+                        $node->parentNode->replaceChild( $frag, $node );
+                        break;
+                    }
+                }
+            }
+        }
+
+        $body = $dom->getElementsByTagName( 'body' )->item( 0 );
+        $new_content = '';
+        foreach ( $body->childNodes as $child ) {
+            $new_content .= $dom->saveHTML( $child );
+        }
+        return $new_content;
+    }
+}
+
+SimpleMaillageSEO::init();
+


### PR DESCRIPTION
## Summary
- provide a simple WordPress plugin called *Simple Maillage SEO*
- document the plugin in French

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6842f74ea0408324ac059daecaaf0a9c